### PR TITLE
Add in-page status indicator for /ai requests

### DIFF
--- a/src/content/__tests__/statusIndicator.test.tsx
+++ b/src/content/__tests__/statusIndicator.test.tsx
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react';
-import { createStatusIndicator } from '../statusIndicator';
+import { createStatusIndicator, StatusIndicator } from '../statusIndicator';
 
 const HOST_ID = 'barra-ai-status-host';
 
@@ -21,9 +21,19 @@ beforeAll(() => {
   });
 });
 
+const indicators: StatusIndicator[] = [];
+const anchors: HTMLElement[] = [];
+
+function makeIndicator(): StatusIndicator {
+  const created = createStatusIndicator();
+  indicators.push(created);
+  return created;
+}
+
 function makeAnchor(rect: Partial<DOMRect> = {}): HTMLElement {
   const el = document.createElement('textarea');
   document.body.appendChild(el);
+  anchors.push(el);
   jest.spyOn(el, 'getBoundingClientRect').mockReturnValue({
     top: 100,
     right: 400,
@@ -45,11 +55,18 @@ function getHost(): HTMLElement | null {
 
 describe('createStatusIndicator', () => {
   afterEach(() => {
-    document.getElementById(HOST_ID)?.remove();
+    // Tear down everything created by the test: hide() unmounts the React
+    // root and removes the scroll/resize listeners; then drop any anchors
+    // appended to document.body. Without this, listeners and roots leak
+    // across tests and make them order-dependent.
+    act(() => {
+      while (indicators.length) indicators.pop()!.hide();
+    });
+    while (anchors.length) anchors.pop()!.remove();
   });
 
   test('show() mounts a host with a shadow root containing the loading copy', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     const anchor = makeAnchor();
 
     act(() => {
@@ -63,7 +80,7 @@ describe('createStatusIndicator', () => {
   });
 
   test('show() renders a Chakra Spinner inside the shadow root', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     const anchor = makeAnchor();
 
     act(() => {
@@ -75,7 +92,7 @@ describe('createStatusIndicator', () => {
   });
 
   test('show() positions the pill using the anchor rect', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     const anchor = makeAnchor({ top: 250, right: 600 });
 
     act(() => {
@@ -91,7 +108,7 @@ describe('createStatusIndicator', () => {
   });
 
   test('show() is idempotent — a second call does not create a second host', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     const anchor = makeAnchor();
 
     act(() => {
@@ -103,7 +120,7 @@ describe('createStatusIndicator', () => {
   });
 
   test('hide() removes the host node', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     const anchor = makeAnchor();
 
     act(() => {
@@ -118,13 +135,13 @@ describe('createStatusIndicator', () => {
   });
 
   test('hide() is safe to call before any show()', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     expect(() => indicator.hide()).not.toThrow();
     expect(getHost()).toBeNull();
   });
 
   test('hide() removes the scroll and resize viewport listeners', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     const anchor = makeAnchor();
     const removeSpy = jest.spyOn(window, 'removeEventListener');
 
@@ -140,7 +157,7 @@ describe('createStatusIndicator', () => {
   });
 
   test('show() can be called again after hide() to remount the indicator', () => {
-    const indicator = createStatusIndicator();
+    const indicator = makeIndicator();
     const anchor = makeAnchor();
 
     act(() => {

--- a/src/content/__tests__/statusIndicator.test.tsx
+++ b/src/content/__tests__/statusIndicator.test.tsx
@@ -1,0 +1,159 @@
+import { act } from '@testing-library/react';
+import { createStatusIndicator } from '../statusIndicator';
+
+const HOST_ID = 'barra-ai-status-host';
+
+// Chakra's color-mode provider calls window.matchMedia; jsdom doesn't ship it.
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+function makeAnchor(rect: Partial<DOMRect> = {}): HTMLElement {
+  const el = document.createElement('textarea');
+  document.body.appendChild(el);
+  jest.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    top: 100,
+    right: 400,
+    bottom: 140,
+    left: 200,
+    width: 200,
+    height: 40,
+    x: 200,
+    y: 100,
+    toJSON: () => ({}),
+    ...rect,
+  } as DOMRect);
+  return el;
+}
+
+function getHost(): HTMLElement | null {
+  return document.getElementById(HOST_ID);
+}
+
+describe('createStatusIndicator', () => {
+  afterEach(() => {
+    document.getElementById(HOST_ID)?.remove();
+  });
+
+  test('show() mounts a host with a shadow root containing the loading copy', () => {
+    const indicator = createStatusIndicator();
+    const anchor = makeAnchor();
+
+    act(() => {
+      indicator.show(anchor);
+    });
+
+    const host = getHost();
+    expect(host).not.toBeNull();
+    expect(host!.shadowRoot).not.toBeNull();
+    expect(host!.shadowRoot!.textContent).toContain('Thinking');
+  });
+
+  test('show() renders a Chakra Spinner inside the shadow root', () => {
+    const indicator = createStatusIndicator();
+    const anchor = makeAnchor();
+
+    act(() => {
+      indicator.show(anchor);
+    });
+
+    const spinner = getHost()!.shadowRoot!.querySelector('.chakra-spinner');
+    expect(spinner).not.toBeNull();
+  });
+
+  test('show() positions the pill using the anchor rect', () => {
+    const indicator = createStatusIndicator();
+    const anchor = makeAnchor({ top: 250, right: 600 });
+
+    act(() => {
+      indicator.show(anchor);
+    });
+
+    const pill = getHost()!.shadowRoot!.querySelector<HTMLElement>(
+      '[data-testid="barra-ai-pill"]'
+    );
+    expect(pill).not.toBeNull();
+    expect(pill!.style.top).toMatch(/^\d+px$/);
+    expect(pill!.style.left).toMatch(/^\d+px$/);
+  });
+
+  test('show() is idempotent — a second call does not create a second host', () => {
+    const indicator = createStatusIndicator();
+    const anchor = makeAnchor();
+
+    act(() => {
+      indicator.show(anchor);
+      indicator.show(anchor);
+    });
+
+    expect(document.querySelectorAll(`#${HOST_ID}`)).toHaveLength(1);
+  });
+
+  test('hide() removes the host node', () => {
+    const indicator = createStatusIndicator();
+    const anchor = makeAnchor();
+
+    act(() => {
+      indicator.show(anchor);
+    });
+    expect(getHost()).not.toBeNull();
+
+    act(() => {
+      indicator.hide();
+    });
+    expect(getHost()).toBeNull();
+  });
+
+  test('hide() is safe to call before any show()', () => {
+    const indicator = createStatusIndicator();
+    expect(() => indicator.hide()).not.toThrow();
+    expect(getHost()).toBeNull();
+  });
+
+  test('hide() removes the scroll and resize viewport listeners', () => {
+    const indicator = createStatusIndicator();
+    const anchor = makeAnchor();
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    act(() => {
+      indicator.show(anchor);
+    });
+    act(() => {
+      indicator.hide();
+    });
+
+    const removed = removeSpy.mock.calls.map(([type]) => type);
+    expect(removed).toEqual(expect.arrayContaining(['scroll', 'resize']));
+  });
+
+  test('show() can be called again after hide() to remount the indicator', () => {
+    const indicator = createStatusIndicator();
+    const anchor = makeAnchor();
+
+    act(() => {
+      indicator.show(anchor);
+    });
+    act(() => {
+      indicator.hide();
+    });
+    act(() => {
+      indicator.show(anchor);
+    });
+
+    expect(getHost()).not.toBeNull();
+    expect(getHost()!.shadowRoot!.textContent).toContain('Thinking');
+  });
+});

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -10,8 +10,10 @@
 // For more information on Content Scripts,
 // See https://developer.chrome.com/extensions/content_scripts
 import { getEditableElement } from './editableElements';
+import { createStatusIndicator } from './statusIndicator';
 
 const AI_COMMAND = '/ai ';
+const statusIndicator = createStatusIndicator();
 
 function handleKeyDown(event: KeyboardEvent): void {
   const activationCmd = event.key === 'Tab';
@@ -33,6 +35,11 @@ function handleKeyDown(event: KeyboardEvent): void {
 
   const prompt = createPrompt(text);
   let accumulatedText = '';
+  let firstChunkHandled = false;
+
+  // Surface "captured + loading" the moment we commit to handling the Tab,
+  // before the port round-trip starts. Hidden on first chunk / done / error.
+  statusIndicator.show(activeElement);
 
   // All inference goes through the background service worker via a Port.
   // The background worker reads storage to decide which provider to use,
@@ -44,11 +51,17 @@ function handleKeyDown(event: KeyboardEvent): void {
       if (msg.type === 'chunk' && msg.content) {
         accumulatedText += msg.content;
         element.setText(accumulatedText);
+        if (!firstChunkHandled) {
+          firstChunkHandled = true;
+          statusIndicator.hide();
+        }
       }
       if (msg.type === 'done') {
+        statusIndicator.hide();
         port.disconnect();
       }
       if (msg.type === 'error') {
+        statusIndicator.hide();
         port.disconnect();
         chrome.runtime
           .sendMessage({

--- a/src/content/statusIndicator.tsx
+++ b/src/content/statusIndicator.tsx
@@ -38,6 +38,7 @@ export function createStatusIndicator(): StatusIndicator {
   let root: ReactDOM.Root | null = null;
   let cache: EmotionCache | null = null;
   let currentAnchor: HTMLElement | null = null;
+  let pendingFrame: number | null = null;
 
   const renderPill = (anchor: HTMLElement) => {
     if (!root || !cache) return;
@@ -73,8 +74,14 @@ export function createStatusIndicator(): StatusIndicator {
     );
   };
 
+  // Coalesce scroll/resize bursts to one render per animation frame so the
+  // React tree isn't re-rendered on every captured scroll event.
   const handleViewportChange = () => {
-    if (currentAnchor) renderPill(currentAnchor);
+    if (pendingFrame !== null) return;
+    pendingFrame = window.requestAnimationFrame(() => {
+      pendingFrame = null;
+      if (currentAnchor) renderPill(currentAnchor);
+    });
   };
 
   return {
@@ -107,6 +114,10 @@ export function createStatusIndicator(): StatusIndicator {
     hide(): void {
       currentAnchor = null;
       if (!host) return;
+      if (pendingFrame !== null) {
+        window.cancelAnimationFrame(pendingFrame);
+        pendingFrame = null;
+      }
       window.removeEventListener('scroll', handleViewportChange, true);
       window.removeEventListener('resize', handleViewportChange);
       root?.unmount();

--- a/src/content/statusIndicator.tsx
+++ b/src/content/statusIndicator.tsx
@@ -1,0 +1,119 @@
+import ReactDOM from 'react-dom/client';
+import { CacheProvider } from '@emotion/react';
+import createCache, { EmotionCache } from '@emotion/cache';
+import { Box, ChakraProvider, HStack, Spinner, Text } from '@chakra-ui/react';
+import theme from '../popup/theme';
+
+const HOST_ID = 'barra-ai-status-host';
+const PILL_OFFSET_PX = 8;
+const VIEWPORT_MARGIN_PX = 4;
+// Worst-case dimensions used only to clamp the pill inside the viewport on
+// tiny fields. The pill itself is sized by its content; these are upper bounds.
+const PILL_ESTIMATED_WIDTH_PX = 110;
+const PILL_ESTIMATED_HEIGHT_PX = 28;
+
+export interface StatusIndicator {
+  show(anchor: HTMLElement): void;
+  hide(): void;
+}
+
+interface PillCoords {
+  top: number;
+  left: number;
+}
+
+function computePosition(anchor: HTMLElement): PillCoords {
+  const rect = anchor.getBoundingClientRect();
+  const top = Math.max(
+    VIEWPORT_MARGIN_PX,
+    rect.top - PILL_ESTIMATED_HEIGHT_PX - PILL_OFFSET_PX
+  );
+  const right = Math.min(window.innerWidth - VIEWPORT_MARGIN_PX, rect.right);
+  const left = Math.max(VIEWPORT_MARGIN_PX, right - PILL_ESTIMATED_WIDTH_PX);
+  return { top, left };
+}
+
+export function createStatusIndicator(): StatusIndicator {
+  let host: HTMLDivElement | null = null;
+  let root: ReactDOM.Root | null = null;
+  let cache: EmotionCache | null = null;
+  let currentAnchor: HTMLElement | null = null;
+
+  const renderPill = (anchor: HTMLElement) => {
+    if (!root || !cache) return;
+    const { top, left } = computePosition(anchor);
+    // Position via inline style so reposition (scroll/resize) doesn't churn a
+    // new emotion class on every render.
+    root.render(
+      <CacheProvider value={cache}>
+        <ChakraProvider theme={theme} resetCSS={false} disableGlobalStyle>
+          <Box
+            data-testid="barra-ai-pill"
+            position="fixed"
+            style={{ top: `${top}px`, left: `${left}px` }}
+            zIndex={2147483647}
+            pointerEvents="none"
+            bg="blackAlpha.800"
+            color="white"
+            px={2.5}
+            py={1}
+            borderRadius="full"
+            boxShadow="md"
+            fontFamily="system-ui, sans-serif"
+          >
+            <HStack spacing={2}>
+              <Spinner size="xs" thickness="2px" speed="0.7s" />
+              <Text fontSize="xs" fontWeight="medium">
+                Thinking…
+              </Text>
+            </HStack>
+          </Box>
+        </ChakraProvider>
+      </CacheProvider>
+    );
+  };
+
+  const handleViewportChange = () => {
+    if (currentAnchor) renderPill(currentAnchor);
+  };
+
+  return {
+    show(anchor: HTMLElement): void {
+      currentAnchor = anchor;
+
+      if (!host) {
+        host = document.createElement('div');
+        host.id = HOST_ID;
+        document.body.appendChild(host);
+        // Open mode so the shadow tree remains inspectable in DevTools and in
+        // tests. Style isolation comes from the shadow boundary itself, not
+        // from the mode.
+        const shadow = host.attachShadow({ mode: 'open' });
+        cache = createCache({ key: 'barra-ai', container: shadow });
+        root = ReactDOM.createRoot(shadow);
+        // Capture-phase scroll catches scrollable ancestors, not just window.
+        window.addEventListener('scroll', handleViewportChange, {
+          passive: true,
+          capture: true,
+        });
+        window.addEventListener('resize', handleViewportChange, {
+          passive: true,
+        });
+      }
+
+      renderPill(anchor);
+    },
+
+    hide(): void {
+      currentAnchor = null;
+      if (!host) return;
+      window.removeEventListener('scroll', handleViewportChange, true);
+      window.removeEventListener('resize', handleViewportChange);
+      root?.unmount();
+      root = null;
+      cache = null;
+      host.remove();
+      host = null;
+    },
+  };
+}


### PR DESCRIPTION
Surface a small Chakra UI pill near the active editable element the moment
Tab is intercepted, so users know their command was captured and a request
is in flight. Hides on first chunk, on done, or on error. Errors continue to
be surfaced by the existing chrome.notifications toast.

The pill renders inside an open shadow root with an Emotion cache scoped to
that root, so host-page CSS can't break it and the popup theme stays reused.

https://claude.ai/code/session_01Cikd7Fis7QSnVTiHVLFME2